### PR TITLE
Restore legacy slide helper compatibility

### DIFF
--- a/lib/adapters/touying.typ
+++ b/lib/adapters/touying.typ
@@ -5,6 +5,6 @@
 #import "@preview/pinit:0.2.2": *
 #import "@preview/cetz:0.4.2"
 #import "../components/boxes.typ": *
-#import "../components/math.typ": pinit-highlight-equation-from
+#import "../components/math.typ": pinit-highlight-equation-from, colormath
 
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))

--- a/lib/components/boxes.typ
+++ b/lib/components/boxes.typ
@@ -18,6 +18,10 @@
   body-color: colors.at("advanced").lighten(80%),
 )
 
+// Backward-compatible aliases for the old slide template API.
+#let showybox_focus = showybox-focus
+#let showybox_advanced = showybox-advanced
+
 #let labeled-box(
   body,
   label: none,
@@ -58,6 +62,24 @@
       #body
     ],
   )
+}
+
+// Legacy state objects kept for compatibility with older slide preambles.
+#let summary-state = state("summary-state", ())
+#let question-state = state("question-state", ())
+#let answer-state = state("answer-state", ())
+
+#let create-box-environment(name, title-text, color, state-obj, numbering: true) = {
+  body => {
+    let key = if numbering { name + "-box-legacy" } else { none }
+    labeled-box(
+      body,
+      label: if title-text == "" { none } else { [#title-text] },
+      color: color,
+      numbering: numbering,
+      key: key,
+    )
+  }
 }
 
 #let question = body => labeled-box(body, label: [Q.], color: colors.at("question"), numbering: true, key: "question-box")

--- a/lib/components/math.typ
+++ b/lib/components/math.typ
@@ -1,6 +1,8 @@
 #import "@preview/pinit:0.2.2": *
 #import "../core/locale.typ": jp-spacing
 
+#let colormath(math, color) = text(fill: color, math)
+
 #let apply-math-font(font: "Latin Modern Math") = {
   show math.equation: set text(font: font)
 }


### PR DESCRIPTION
## Summary
- restore legacy slide helper exports such as `colormath`, `showybox_focus`, and `showybox_advanced`
- add compatibility aliases for legacy slide box helpers and state objects used by older preambles
- keep the current slide preset implementation intact while making migration from the old template easier

## Test Plan
- `typst compile --root . starters/slide.typ /tmp/compat-starter-slide.pdf`
- `typst compile --root . examples/slide.typ /tmp/compat-example-slide.pdf`
