### PR TITLE
[codex] Enable cjk-spacer in presets

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -11,6 +11,8 @@
 
 ## Shared Packages
 
+- `@preview/cjk-spacer:0.2.0`
+  Automatic spacing between CJK and Latin text in all presets.
 - `@preview/pinit:0.2.2`
   Equation annotation pins and arrows.
 - `@preview/physica:0.9.8`

--- a/lib/presets/document.typ
+++ b/lib/presets/document.typ
@@ -1,3 +1,4 @@
+#import "@preview/cjk-spacer:0.2.0": cjk-spacer
 #import "@preview/physica:0.9.8": *
 #import "@preview/cetz:0.4.2"
 #import "@preview/unify:0.7.1": *
@@ -7,6 +8,7 @@
 
 #let setup-document(body, config: none) = {
   let resolved = document-config(overrides: config)
+  show: cjk-spacer
   show: js-document.with(config: resolved)
   apply-document-bibliography()
   set math.equation(numbering: resolved.at("equation-numbering"))

--- a/lib/presets/poster.typ
+++ b/lib/presets/poster.typ
@@ -1,3 +1,4 @@
+#import "@preview/cjk-spacer:0.2.0": cjk-spacer
 #import "../core/config.typ": poster-config
 #import "../core/journal-abbrev.typ": abbreviate-journal
 #import "../core/locale.typ": apply-japanese-text
@@ -160,6 +161,7 @@
 #let poster-theme(body, config: none) = {
   let resolved = poster-config(overrides: config)
   let metadata = resolved.at("metadata")
+  show: cjk-spacer
   set page("a0", margin: 1cm)
   pop.set-poster-layout(pop.layout-a0)
   pop.set-theme(pop.psi-ch)

--- a/lib/presets/slide.typ
+++ b/lib/presets/slide.typ
@@ -1,3 +1,4 @@
+#import "@preview/cjk-spacer:0.2.0": cjk-spacer
 #import "../core/config.typ": slide-config
 #import "../core/locale.typ": apply-japanese-text
 #import "../components/math.typ": apply-math-font, apply-inline-japanese-math-spacing, apply-block-equation-spacing
@@ -22,6 +23,7 @@
   let resolved = slide-config(overrides: config)
   let metadata = resolved.at("metadata")
   let datetime-format = resolve-slide-datetime-format(resolved)
+  show: cjk-spacer
   set text(font: resolved.at("text-font"))
   apply-math-font(font: resolved.at("math-font"))
   apply-japanese-text(cjk-font: resolved.at("cjk-font"))


### PR DESCRIPTION
## Summary
- enable `@preview/cjk-spacer:0.2.0` by default in the document, slide, and poster presets
- keep the integration at preset boundaries by adding `show: cjk-spacer` in each preset setup/theme function
- document the shared dependency in `docs/dependencies.md`

## Why
Users currently need to wire CJK/Latin auto-spacing themselves. Making this part of the presets keeps Japanese-friendly defaults consistent across all template entry points.

## Validation
- `typst compile --root . starters/document-jp.typ /tmp/document-jp-pr.pdf`
- `typst compile --root . starters/slide.typ /tmp/slide-pr.pdf`
- `typst compile --root . starters/poster.typ /tmp/poster-pr.pdf`