### PR TITLE
[codex] Add Beamer-style slide helper blocks

### DIFF
--- a/examples/slide.typ
+++ b/examples/slide.typ
@@ -41,6 +41,19 @@
   #summary-no-num[囲み枠コンポーネントは slide と poster で共通利用できます。]
 ]
 
+== Beamer-style helpers
+#slide[
+  #structure[構造化した主張] は通常の強調、#alert[注意すべき条件] は警告に使えます。
+
+  #structure-block(title: [Structure])[主要な概念や前提を短くまとめます。]
+  #alert-block(title: [Alert])[仮定が破れる場合や重要な制約を示します。]
+  #example-block(title: [Example])[具体例や計算例を置けます。]
+
+  #structure-colorbox[Structure] #h(0.4em)
+  #alert-colorbox[Alert] #h(0.4em)
+  #example-colorbox[Example]
+]
+
 == 2カラムレイアウト
 #slide[
   左カラムには短い箇条書きを置けます。

--- a/lib/components/boxes.typ
+++ b/lib/components/boxes.typ
@@ -8,6 +8,18 @@
   text,
 )
 
+#let semantic-text(body, color) = text(fill: color, weight: "bold", body)
+#let structure = body => semantic-text(body, colors.at("structure"))
+#let alert = body => semantic-text(body, colors.at("alert"))
+
+#let semantic-colorbox(body, color, baseline: 0%) = box(
+  fill: color.lighten(70%),
+  inset: (x: 0.45em, y: 0.18em),
+  radius: 3pt,
+  baseline: baseline,
+  body,
+)
+
 #let showybox-focus = (
   border-color: white,
   body-color: colors.at("accent").lighten(70%),
@@ -65,6 +77,22 @@
     ],
   )
 }
+
+#let semantic-block(body, title: none, color: gray) = labeled-box(
+  body,
+  label: title,
+  color: color,
+  numbering: false,
+  title-fill: color.darken(20%),
+)
+
+#let structure-block(body, title: none) = semantic-block(body, title: title, color: colors.at("structure"))
+#let alert-block(body, title: none) = semantic-block(body, title: title, color: colors.at("alert"))
+#let example-block(body, title: none) = semantic-block(body, title: title, color: colors.at("example"))
+
+#let structure-colorbox = body => semantic-colorbox(body, colors.at("structure"))
+#let alert-colorbox = body => semantic-colorbox(body, colors.at("alert"))
+#let example-colorbox = body => semantic-colorbox(body, colors.at("example"))
 
 // Legacy state objects kept for compatibility with older slide preambles.
 #let summary-state = state("summary-state", ())

--- a/lib/core/tokens.typ
+++ b/lib/core/tokens.typ
@@ -1,7 +1,10 @@
 #let colors = (
   accent: rgb("#f93d6e"),
+  structure: rgb("#1f4e79"),
+  alert: rgb("#F77F00"),
+  example: rgb("#2d6a4f"),
   question: rgb("#FFB11B"),
-  answer: rgb("#E03C8A"),
+  answer: rgb("#B23A8E"),
   advanced: orange,
   muted: gray,
   navy: navy,


### PR DESCRIPTION
## Summary

- Add semantic slide colors for structure, alert, example, and answer roles.
- Add Beamer-style `structure`, `alert`, block, and compact colorbox helpers through the existing slide preset import surface.
- Add a short slide example showing the new helper vocabulary.

Closes #10

## Test Plan

- `typst compile --root . examples/slide.typ /tmp/typst-templates-pr-final-slide-example.pdf`
- `typst compile --root . starters/slide.typ /tmp/typst-templates-pr-final-slide-starter.pdf`
- `typst compile --root . examples/poster.typ /tmp/typst-templates-pr-final-poster-example.pdf`
- `typst compile --root . starters/poster.typ /tmp/typst-templates-pr-final-poster-starter.pdf`
- `typst compile --root . examples/document-jp.typ /tmp/typst-templates-pr-final-document-example.pdf`
- `typst compile --root . starters/document-jp.typ /tmp/typst-templates-pr-final-document-starter.pdf`
- `git diff --check main...HEAD`
