### PR TITLE
[codex] Add slide typography and palette tokens

### DIFF
--- a/examples/slide.typ
+++ b/examples/slide.typ
@@ -89,6 +89,36 @@
   $
 ]
 
+== Palette and code
+#slide[
+  `slide-palette` はグラフや図注で再利用しやすい色名を提供します。
+
+  #let swatch(name, color) = stack(
+    dir: ttb,
+    spacing: 0.12em,
+    rect(width: 100%, height: 0.42cm, fill: color),
+    text(size: 0.75em, name),
+  )
+
+  #grid(
+    columns: (1fr, 1fr, 1fr, 1fr),
+    gutter: 0.8em,
+    swatch("blue", slide-palette.blue),
+    swatch("orange", slide-palette.orange),
+    swatch("green", slide-palette.green),
+    swatch("red", slide-palette.red),
+    swatch("cyan", slide-palette.cyan),
+    swatch("purple", slide-palette.purple),
+    swatch("brown", slide-palette.brown),
+    swatch("gray", slide-palette.gray),
+  )
+
+  ```typ
+  #let fit = model(data)
+  plot(fit, stroke: slide-palette.blue)
+  ```
+]
+
 == CeTZ
 #slide[
   #align(center)[#cetz.canvas({

--- a/lib/core/tokens.typ
+++ b/lib/core/tokens.typ
@@ -13,8 +13,20 @@
   document-sans: "Liberation Sans",
   document-sans-cjk: "IPAexGothic",
   ui: "Cabin",
+  code: "Noto Sans Mono",
   math: "Latin Modern Math",
   cjk: "Noto Sans CJK JP",
+)
+
+#let slide-palette = (
+  blue: rgb("#4E79A7"),
+  orange: rgb("#F28E2B"),
+  green: rgb("#59A14F"),
+  red: rgb("#E15759"),
+  cyan: rgb("#76B7B2"),
+  purple: rgb("#B07AA1"),
+  brown: rgb("#9C755F"),
+  gray: rgb("#BAB0AC"),
 )
 
 #let spacing = (
@@ -47,6 +59,7 @@
   text-font: fonts.at("ui"),
   cjk-font: fonts.at("cjk"),
   math-font: fonts.at("math"),
+  code-font: fonts.at("code"),
   title: [Presentation title\ ...continued to the second line],
   subtitle: [Subtitle],
   author: [

--- a/lib/presets/slide.typ
+++ b/lib/presets/slide.typ
@@ -1,5 +1,6 @@
 #import "@preview/cjk-spacer:0.2.0": cjk-spacer
 #import "../core/config.typ": slide-config
+#import "../core/tokens.typ": slide-palette
 #import "../core/locale.typ": apply-japanese-text
 #import "../components/aligned-list.typ": aligned-items, aligned-enum
 #import "../components/math.typ": apply-math-font, apply-inline-japanese-math-spacing, apply-block-equation-spacing
@@ -26,6 +27,14 @@
   let datetime-format = resolve-slide-datetime-format(resolved)
   show: cjk-spacer
   set text(font: resolved.at("text-font"))
+  show raw: set text(font: resolved.at("code-font"))
+  show raw.where(block: true): set block(
+    fill: rgb("#f6f7f9"),
+    stroke: rgb("#d9dde3"),
+    inset: 0.65em,
+    radius: 4pt,
+    width: 100%,
+  )
   apply-math-font(font: resolved.at("math-font"))
   apply-japanese-text(cjk-font: resolved.at("cjk-font"))
   apply-inline-japanese-math-spacing()


### PR DESCRIPTION
## Summary
- Add a `code-font` slide default backed by `Noto Sans Mono`.
- Add a small Tableau-like `slide-palette` for figure-friendly slide colors and expose it through the slide preset import surface.
- Style slide raw/code blocks by default and add palette/code examples to `examples/slide.typ`.

## Impact
Slide users can reuse named palette colors such as `slide-palette.blue` and get framed raw code blocks from the slide preset without adding dependencies. `starters/slide.typ` is unchanged.

## Validation
- `typst compile --root . examples/slide.typ /tmp/issue11-examples-slide-pr.pdf`
- `typst compile --root . starters/slide.typ /tmp/issue11-starters-slide-pr.pdf`

Closes #11