### PR TITLE
Add referenced-only equation numbering for slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@
 `date-locale` を追加すると，日付表示を日本語に切り替えられる．
 既定値は `"en"` で，`datetime-format` を明示した場合はその指定が優先される．
 title slide では各著者が `氏名 `メールアドレス` 所属` の1行形式で表示され，`authors[].email` が空ならその部分は省略される．
+数式番号を参照された表示式だけに付けたい場合は，slide metadata に
+`equation-numbering: "referenced-only"` と `equation-numbering-pattern: "(1)"` を追加する．
+この設定は slide preset だけに効き，未ラベルの表示式は番号なし，ラベル付き表示式と `@eq` 参照は同じ番号へリンクされる．
 
 ### Poster logo strip
 

--- a/examples/slide.typ
+++ b/examples/slide.typ
@@ -24,6 +24,8 @@
   logo: [],
   logo-position: "right-bottom",
   bibliography: none,
+  equation-numbering: "referenced-only",
+  equation-numbering-pattern: "(1)",
 )
 
 #show: slide-theme.with(config: metadata + (date-locale: "ja"))
@@ -84,6 +86,19 @@
       ([Step 2], [右列に説明や補足を置きます。]),
     ),
   )
+]
+
+== 参照された数式番号
+#slide[
+  $
+    a^2 + b^2 = c^2
+  $
+
+  $
+    e = m c^2
+  $ <eq:mass-energy>
+
+  参照した式 @eq:mass-energy だけに番号が付きます。
 ]
 
 == 注釈付き数式

--- a/lib/components/math.typ
+++ b/lib/components/math.typ
@@ -11,6 +11,31 @@
   show math.equation.where(block: true): set block(spacing: spacing)
 }
 
+#let apply-referenced-only-equation-numbering(numbering: "(1)") = body => {
+  show math.equation: it => {
+    if it.block and it.has("label") and it.numbering == none {
+      math.equation(it.body, block: true, numbering: numbering)
+    } else {
+      it
+    }
+  }
+  show ref: it => {
+    let el = it.element
+    if el == none or el.func() != math.equation {
+      it
+    } else {
+      {
+        let nums = counter(math.equation).at(el.location())
+        let last-index = nums.len() - 1
+        let current = nums.at(last-index) + 1
+        let display-nums = nums.slice(0, last-index) + (current,)
+        link(el.location(), std.numbering(numbering, ..display-nums))
+      }
+    }
+  }
+  body
+}
+
 #let apply-inline-japanese-math-spacing() = {
   show math.equation.where(block: false): it => jp-spacing(it)
 }

--- a/lib/core/tokens.typ
+++ b/lib/core/tokens.typ
@@ -82,6 +82,8 @@
   datetime-format: auto,
   footer-columns: (45%, 45%, 10%),
   handout: false,
+  equation-numbering: none,
+  equation-numbering-pattern: "(1)",
 )
 
 #let poster-defaults = (

--- a/lib/presets/slide.typ
+++ b/lib/presets/slide.typ
@@ -3,7 +3,7 @@
 #import "../core/tokens.typ": slide-palette
 #import "../core/locale.typ": apply-japanese-text
 #import "../components/aligned-list.typ": aligned-items, aligned-enum
-#import "../components/math.typ": apply-math-font, apply-inline-japanese-math-spacing, apply-block-equation-spacing
+#import "../components/math.typ": apply-math-font, apply-inline-japanese-math-spacing, apply-block-equation-spacing, apply-referenced-only-equation-numbering
 #import "../adapters/touying.typ": *
 
 #let slide-date-formats = (
@@ -20,6 +20,106 @@
     slide-date-formats.at(locale, default: slide-date-formats.at("en"))
   }
 }
+
+#let slide(
+  config: (:),
+  repeat: auto,
+  setting: body => body,
+  composer: auto,
+  align: auto,
+  ..bodies,
+) = touying-slide-wrapper(self => {
+  if align != auto {
+    self.store.align = align
+  }
+  let header(self) = {
+    set std.align(top)
+    grid(
+      rows: (auto, auto),
+      row-gutter: 3mm,
+      if self.store.progress-bar {
+        components.progress-bar(
+          height: 2pt,
+          self.colors.primary,
+          self.colors.tertiary,
+        )
+      },
+      block(
+        inset: (x: .5em),
+        components.left-and-right(
+          text(
+            fill: self.colors.primary,
+            weight: "bold",
+            size: 1.2em,
+            utils.call-or-display(self, self.store.header),
+          ),
+          text(fill: self.colors.primary.lighten(65%), utils.call-or-display(
+            self,
+            self.store.header-right,
+          )),
+        ),
+      ),
+    )
+  }
+  let footer(self) = {
+    set std.align(center + bottom)
+    set text(size: .4em)
+    {
+      let cell(..args, it) = components.cell(
+        ..args,
+        inset: 1mm,
+        std.align(horizon, text(fill: white, it)),
+      )
+      show: block.with(width: 100%, height: auto)
+      grid(
+        columns: self.store.footer-columns,
+        rows: 1.5em,
+        cell(fill: self.colors.primary, utils.call-or-display(
+          self,
+          self.store.footer-a,
+        )),
+        cell(fill: self.colors.secondary, utils.call-or-display(
+          self,
+          self.store.footer-b,
+        )),
+        cell(fill: self.colors.tertiary, utils.call-or-display(
+          self,
+          self.store.footer-c,
+        )),
+      )
+    }
+  }
+  let self = utils.merge-dicts(
+    self,
+    config-page(
+      header: header,
+      footer: footer,
+    ),
+  )
+  let new-setting = body => {
+    show: std.align.with(self.store.align)
+    show: setting
+    body
+  }
+  let slide-bodies = if self.at("equation-numbering", default: none) == "referenced-only" {
+    bodies.pos().map(body => {
+      show: apply-referenced-only-equation-numbering(
+        numbering: self.at("equation-numbering-pattern", default: "(1)"),
+      )
+      body
+    })
+  } else {
+    bodies.pos()
+  }
+  touying-slide(
+    self: self,
+    config: config,
+    repeat: repeat,
+    setting: new-setting,
+    composer: composer,
+    ..slide-bodies,
+  )
+})
 
 #let slide-theme(body, config: none) = {
   let resolved = slide-config(overrides: config)
@@ -39,7 +139,6 @@
   apply-japanese-text(cjk-font: resolved.at("cjk-font"))
   apply-inline-japanese-math-spacing()
   apply-block-equation-spacing()
-
   show: university-theme.with(
     header-right: "",
     footer-columns: resolved.at("footer-columns"),
@@ -69,7 +168,11 @@
       logo-position: metadata.at("logo-position"),
       summary: metadata.at("summary"),
     ),
-    config-common(datetime-format: datetime-format),
+    config-common(
+      datetime-format: datetime-format,
+      equation-numbering: resolved.at("equation-numbering"),
+      equation-numbering-pattern: resolved.at("equation-numbering-pattern"),
+    ),
     // config-common(new-section-slide-fn: none),
     config-common(handout: resolved.at("handout")),
   )


### PR DESCRIPTION
## Summary
- Add an opt-in referenced-only equation numbering helper in `lib/components/math.typ`.
- Wire slide config through `equation-numbering: "referenced-only"` and `equation-numbering-pattern` without changing document/poster defaults.
- Add a slide catalog example and README note for the new mode.

Closes #14.

## Test Plan
- `typst compile --root . starters/slide.typ /tmp/issue14-pr-starter-slide.pdf`
- `typst compile --root . examples/slide.typ /tmp/issue14-pr-example-slide.pdf`
- `typst compile --root . examples/document-jp.typ /tmp/issue14-pr-document-jp.pdf`
- `typst compile --root . examples/poster.typ /tmp/issue14-pr-poster.pdf`
- `pdftotext -layout /tmp/issue14-pr-example-slide.pdf -` confirmed the new slide has no number on the unlabeled equation and `(1)` on the labeled equation/reference.
