### PR TITLE
[codex] Add footer-preserving slide section helpers

### DIFF
--- a/examples/slide-focus.typ
+++ b/examples/slide-focus.typ
@@ -1,0 +1,40 @@
+#import "../lib/presets/slide.typ": *
+
+#let metadata = (
+  title: [Footer slide helpers],
+  subtitle: [Section and focus slides],
+  authors: (
+    (
+      name: [Ryo Araki],
+      affiliation: [Typst Templates],
+      email: [],
+    ),
+  ),
+  date: datetime.today(),
+  summary: [footer helpers],
+  abstract: [],
+  venue: [],
+  logo: [],
+  bibliography: none,
+)
+
+#show: slide-theme.with(config: metadata)
+#slide-title-slide()
+
+= Motivation
+
+== Context
+
+#slide[
+  The default slide theme keeps its footer navigation and metadata.
+]
+
+= Main message
+
+#footer-focus-slide[
+  Use one slide for one important message.
+]
+
+#slide-section-slide[
+  Explicit section divider
+]

--- a/lib/presets/slide.typ
+++ b/lib/presets/slide.typ
@@ -121,6 +121,42 @@
   )
 })
 
+#let slide-section-slide(
+  config: (:),
+  level: 1,
+  numbered: false,
+  ..args,
+) = touying-slide-wrapper(self => {
+  self = utils.merge-dicts(self, config)
+  let body = args.pos().at(0, default: none)
+  let title = if body == none or body == [] {
+    utils.display-current-heading(level: level, numbered: numbered)
+  } else {
+    body
+  }
+  touying-slide(
+    self: self,
+    std.align(center + horizon)[
+      #set text(size: 1.8em, fill: self.colors.primary, weight: "bold")
+      #title
+    ],
+  )
+})
+
+#let footer-focus-slide(
+  body,
+  config: (:),
+) = touying-slide-wrapper(self => {
+  self = utils.merge-dicts(self, config)
+  touying-slide(
+    self: self,
+    std.align(center + horizon)[
+      #set text(size: 1.7em, fill: self.colors.primary, weight: "bold")
+      #body
+    ],
+  )
+})
+
 #let slide-theme(body, config: none) = {
   let resolved = slide-config(overrides: config)
   let metadata = resolved.at("metadata")
@@ -173,7 +209,7 @@
       equation-numbering: resolved.at("equation-numbering"),
       equation-numbering-pattern: resolved.at("equation-numbering-pattern"),
     ),
-    // config-common(new-section-slide-fn: none),
+    config-common(new-section-slide-fn: slide-section-slide.with(numbered: false)),
     config-common(handout: resolved.at("handout")),
   )
   body
@@ -272,3 +308,4 @@
   }
   touying-slide(self: self, body)
 })
+


### PR DESCRIPTION
## Summary
- Add `slide-section-slide` for footer-theme section divider slides and wire it into `slide-theme` as the Touying section-slide hook.
- Add `footer-focus-slide` for footer-preserving one-message emphasis slides without overriding Touying's existing `focus-slide` helper.
- Add `examples/slide-focus.typ` as a compact example for section dividers and footer-preserving focus slides.

Closes #13.

## Test Plan
- `typst compile --root . starters/slide.typ /tmp/starter-slide.pdf`
- `typst compile --root . examples/slide.typ /tmp/example-slide.pdf`
- `typst compile --root . examples/slide-focus.typ /tmp/example-slide-focus.pdf`
